### PR TITLE
docs: fix grammar and clarity in contract documentation  

### DIFF
--- a/contracts/docs/Prover.md
+++ b/contracts/docs/Prover.md
@@ -68,7 +68,7 @@ Emit when new prover register and waiting reviewing
 event TransferProver(address prover, address owner)
 ```
 
-Emit when prover owner transfer to others
+Emit when prover owner transfers to others
 
 ### UpgradeProver
 
@@ -76,7 +76,7 @@ Emit when prover owner transfer to others
 event UpgradeProver(address prover, enum ProverType ptype, uint256 work, uint256 version, uint256 overtime, address verifier, string name, string types)
 ```
 
-Emit when the prover start upgrading and waiting reviewing, before approve, it will still use old info
+Emit when the prover start upgrading and waiting reviewing, before approval, it will still use old info
 
 ### ApproveProver
 
@@ -84,7 +84,7 @@ Emit when the prover start upgrading and waiting reviewing, before approve, it w
 event ApproveProver(address prover, enum ProverType ptype, uint256 work, uint256 epoch, uint256 version, uint256 overtime, address verifier, string types, bool minable, bool approved)
 ```
 
-Emit when the prover is approved or reject
+Emit when the prover is approved or rejected
 
 ### StopProver
 

--- a/contracts/docs/ProverMarket.md
+++ b/contracts/docs/ProverMarket.md
@@ -66,7 +66,7 @@ Emit when new prover register and waiting reviewing
 event TransferProver(address prover, address owner)
 ```
 
-Emit when prover owner transfer to others
+Emit when prover owner transfers to others
 
 ### UpgradeProver
 
@@ -74,7 +74,7 @@ Emit when prover owner transfer to others
 event UpgradeProver(address prover, uint256 work, uint256 version, uint256 overtime, address verifier)
 ```
 
-Emit when the prover start upgrading and waiting reviewing, before approve, it will still use old info
+Emit when the prover start upgrading and waiting reviewing, before approval, it will still use old info
 
 ### ApproveProver
 

--- a/contracts/docs/Reward.md
+++ b/contracts/docs/Reward.md
@@ -384,7 +384,7 @@ Miner collect reward in epoch and prover, collect reward to unstaking list
 function playerCollect(uint256 epoch, address prover, address player) public
 ```
 
-Player collect reward in epoch and prover, collect to player wallet
+Player collect reward in epoch and prover, collect to player's wallet
 
 #### Parameters
 


### PR DESCRIPTION

- **Prover.md**  
  - "transfer to others" → "transfers to others"  
  - "before approve" → "before approval"  
  - "approved or reject" → "approved or rejected"  

- **ProverMarket.md**  
  - "transfer to others" → "transfers to others"  
  - "before approve" → "before approval"  

- **Reward.md**  
  - "collect to player wallet" → "collect to player's wallet"  